### PR TITLE
remove the countAtRank attribute from the percentile gauges

### DIFF
--- a/src/main/scala/kamon/newrelic/AttributeBuddy.scala
+++ b/src/main/scala/kamon/newrelic/AttributeBuddy.scala
@@ -43,7 +43,7 @@ object AttributeBuddy {
 
   def buildCommonAttributes(environment: Environment): Attributes = {
     val attributes = new Attributes()
-      .put("instrumentation.source", "kamon-agent")
+      .put("instrumentation.provider", "kamon-agent")
       .put("service.name", environment.service)
       .put("host", environment.host)
     AttributeBuddy.addTagsFromTagSets(Seq(environment.tags), attributes)

--- a/src/main/scala/kamon/newrelic/AttributeBuddy.scala
+++ b/src/main/scala/kamon/newrelic/AttributeBuddy.scala
@@ -6,8 +6,7 @@
 package kamon.newrelic
 
 import com.newrelic.telemetry.Attributes
-import com.typesafe.config.{Config, ConfigValue}
-import kamon.Kamon
+import com.typesafe.config.Config
 import kamon.status.Environment
 import kamon.tag.{Tag, TagSet}
 
@@ -47,7 +46,7 @@ object AttributeBuddy {
       .put("instrumentation.source", "kamon-agent")
       .put("service.name", environment.service)
       .put("host", environment.host)
-      AttributeBuddy.addTagsFromTagSets(Seq(environment.tags), attributes)
+    AttributeBuddy.addTagsFromTagSets(Seq(environment.tags), attributes)
     attributes
   }
 }

--- a/src/main/scala/kamon/newrelic/metrics/NewRelicDistributionMetrics.scala
+++ b/src/main/scala/kamon/newrelic/metrics/NewRelicDistributionMetrics.scala
@@ -10,7 +10,6 @@ import com.newrelic.telemetry.metrics.{Gauge, Metric, Summary}
 import kamon.metric.Distribution.Bucket
 import kamon.metric.MetricSnapshot.Distributions
 import kamon.metric.{Distribution, DynamicRange, MeasurementUnit, MetricSnapshot}
-import kamon.newrelic.AttributeBuddy
 import kamon.newrelic.AttributeBuddy._
 import kamon.tag.TagSet
 import org.slf4j.LoggerFactory
@@ -53,7 +52,6 @@ object NewRelicDistributionMetrics {
       .filter(percentileValue => percentileValue != null)
       .map { percentile =>
         val attributes: Attributes = instrumentBaseAttributes.copy()
-          .put("percentile.countAtRank", percentile.countAtRank)
           .put("percentile", percentile.rank)
         new Gauge(name + ".percentiles", percentile.value, end, attributes)
       }

--- a/src/main/scala/kamon/newrelic/metrics/NewRelicMetricsReporter.scala
+++ b/src/main/scala/kamon/newrelic/metrics/NewRelicMetricsReporter.scala
@@ -41,6 +41,8 @@ class NewRelicMetricsReporter(senderBuilder: () => MetricBatchSender = () => New
       NewRelicDistributionMetrics(periodStartTime, periodEndTime, timer, "timer")
     }
 
+    //todo: add range sampler metrics as well
+
     val metrics = Seq(counters, gauges, histogramMetrics, timerMetrics).flatten.asJava
     val batch = new MetricBatch(metrics, commonAttributes)
 

--- a/src/test/scala/kamon/newrelic/metrics/NewRelicDistributionMetricsSpec.scala
+++ b/src/test/scala/kamon/newrelic/metrics/NewRelicDistributionMetricsSpec.scala
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2019 New Relic Corporation. All rights reserved.
+ *  Copyright 2020 New Relic Corporation. All rights reserved.
  *  SPDX-License-Identifier: Apache-2.0
  */
 
@@ -25,7 +25,7 @@ class NewRelicDistributionMetricsSpec extends WordSpec with Matchers {
         .put("dimension", "information")
         .put("sourceMetricType", "mountain")
       val summary = new Summary("trev.summary", 44, 101.0, 13.0, 17.0, TestMetricHelper.start, TestMetricHelper.end, summaryAttributes)
-      val gaugeAttributes = summaryAttributes.copy().put("percentile.countAtRank", 816L).put("percentile", 90.0d)
+      val gaugeAttributes = summaryAttributes.copy().put("percentile", 90.0d)
       val gauge = new Gauge("trev.percentiles", 2.0, TestMetricHelper.end, gaugeAttributes)
       val expectedMetrics = Seq(gauge, summary)
       val result = NewRelicDistributionMetrics(TestMetricHelper.start, TestMetricHelper.end, distributions, "mountain")

--- a/src/test/scala/kamon/newrelic/metrics/NewRelicMetricsReporterSpec.scala
+++ b/src/test/scala/kamon/newrelic/metrics/NewRelicMetricsReporterSpec.scala
@@ -83,7 +83,7 @@ class NewRelicMetricsReporterSpec extends WordSpec with Matchers {
 
       val expectedCommonAttributes: Attributes = new Attributes()
         .put("service.name", "kamon-application")
-        .put("instrumentation.source", "kamon-agent")
+        .put("instrumentation.provider", "kamon-agent")
         .put("host", InetAddress.getLocalHost.getHostName)
         .put("testTag", "testValue")
       val expectedBatch: MetricBatch = new MetricBatch(Seq(count1, count2, gauge, histogramGauge, histogramSummary, timerGauge, timerSummary).asJava, expectedCommonAttributes)
@@ -105,7 +105,7 @@ class NewRelicMetricsReporterSpec extends WordSpec with Matchers {
 
       val expectedCommonAttributes: Attributes = new Attributes()
         .put("service.name", "cheese-whiz")
-        .put("instrumentation.source", "kamon-agent")
+        .put("instrumentation.provider", "kamon-agent")
         .put("testTag", "testThing")
         .put("host", "thing")
       val expectedBatch: MetricBatch = new MetricBatch(Seq(count1, count2, gauge, histogramGauge, histogramSummary).asJava, expectedCommonAttributes)

--- a/src/test/scala/kamon/newrelic/metrics/NewRelicMetricsReporterSpec.scala
+++ b/src/test/scala/kamon/newrelic/metrics/NewRelicMetricsReporterSpec.scala
@@ -63,12 +63,12 @@ class NewRelicMetricsReporterSpec extends WordSpec with Matchers {
   private val gauge: Metric = new Gauge("shirley", 15.6d, TestMetricHelper.end, gaugeAttributes)
 
   private val histogramGauge: Metric = new Gauge("trev.percentiles", 2.0, TestMetricHelper.end,
-    histogramSummaryAttributes.copy().put("percentile.countAtRank", 816L).put("percentile", 90.0d))
+    histogramSummaryAttributes.copy().put("percentile", 90.0d))
   private val histogramSummary: Metric = new Summary("trev.summary", 44, 101.0, 13.0, 17.0,
     TestMetricHelper.start, TestMetricHelper.end, histogramSummaryAttributes)
 
   private val timerGauge: Metric = new Gauge("timer.percentiles", 4.0, TestMetricHelper.end,
-    timerSummaryAttributes.copy().put("percentile.countAtRank", 1632L).put("percentile", 95.0d))
+    timerSummaryAttributes.copy().put("percentile", 95.0d))
   private val timerSummary: Metric = new Summary("timer.summary", 88, 202.0, 26.0, 34.0,
     TestMetricHelper.start, TestMetricHelper.end, timerSummaryAttributes)
 

--- a/src/test/scala/kamon/newrelic/spans/NewRelicSpanReporterSpec.scala
+++ b/src/test/scala/kamon/newrelic/spans/NewRelicSpanReporterSpec.scala
@@ -75,7 +75,7 @@ class NewRelicSpanReporterSpec extends WordSpec with Matchers {
       .parentId(TestSpanHelper.parentId)
       .build()
     val commonAttributes = new Attributes()
-      .put("instrumentation.source", "kamon-agent")
+      .put("instrumentation.provider", "kamon-agent")
       .put("service.name", serviceName)
       .put("host", hostName)
       .put("testTag", tagValue)


### PR DESCRIPTION
Since it can/will vary with every reporting cycle, it would blow out cardinality limits very quickly.
It is derivable from the summary data and the percentile rank if it needs to be reconstructed.

This also renames a mis-named attribute.