### PR TITLE
Update to the latest NR telemetry SDK

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,8 +25,8 @@ resolvers += Resolver.bintrayRepo("kamon-io", "snapshots")
 
 libraryDependencies ++= Seq(
   "io.kamon" %% "kamon-core" % "2.0.1",
-  "com.newrelic.telemetry" % "telemetry" % "0.3.4",
-  "com.newrelic.telemetry" % "telemetry-http-okhttp" % "0.3.4",
+  "com.newrelic.telemetry" % "telemetry" % "0.4.0",
+  "com.newrelic.telemetry" % "telemetry-http-okhttp" % "0.4.0",
   scalatest % "test",
   "org.mockito" % "mockito-core" % "3.1.0" % "test"
 )

--- a/src/main/scala/kamon/newrelic/AttributeBuddy.scala
+++ b/src/main/scala/kamon/newrelic/AttributeBuddy.scala
@@ -45,7 +45,7 @@ object AttributeBuddy {
     val attributes = new Attributes()
       .put("instrumentation.provider", "kamon-agent")
       .put("service.name", environment.service)
-      .put("host", environment.host)
+      .put("host.hostname", environment.host)
     AttributeBuddy.addTagsFromTagSets(Seq(environment.tags), attributes)
     attributes
   }

--- a/src/main/scala/kamon/newrelic/metrics/NewRelicMetricsReporter.scala
+++ b/src/main/scala/kamon/newrelic/metrics/NewRelicMetricsReporter.scala
@@ -12,6 +12,7 @@ import kamon.Kamon
 import kamon.metric.PeriodSnapshot
 import kamon.module.{MetricReporter, Module, ModuleFactory}
 import kamon.newrelic.AttributeBuddy.buildCommonAttributes
+import kamon.newrelic.LibraryVersion
 import kamon.status.Environment
 import org.slf4j.LoggerFactory
 
@@ -76,6 +77,7 @@ object NewRelicMetricsReporter {
     val nrInsightsInsertKey = nrConfig.getString("nr-insights-insert-key")
     SimpleMetricBatchSender.builder(nrInsightsInsertKey)
       .enableAuditLogging()
+      .secondaryUserAgent("newrelic-kamon-reporter", LibraryVersion.version)
       .build()
   }
 }

--- a/src/test/scala/kamon/newrelic/metrics/NewRelicMetricsReporterSpec.scala
+++ b/src/test/scala/kamon/newrelic/metrics/NewRelicMetricsReporterSpec.scala
@@ -84,7 +84,7 @@ class NewRelicMetricsReporterSpec extends WordSpec with Matchers {
       val expectedCommonAttributes: Attributes = new Attributes()
         .put("service.name", "kamon-application")
         .put("instrumentation.provider", "kamon-agent")
-        .put("host", InetAddress.getLocalHost.getHostName)
+        .put("host.hostname", InetAddress.getLocalHost.getHostName)
         .put("testTag", "testValue")
       val expectedBatch: MetricBatch = new MetricBatch(Seq(count1, count2, gauge, histogramGauge, histogramSummary, timerGauge, timerSummary).asJava, expectedCommonAttributes)
 
@@ -107,7 +107,7 @@ class NewRelicMetricsReporterSpec extends WordSpec with Matchers {
         .put("service.name", "cheese-whiz")
         .put("instrumentation.provider", "kamon-agent")
         .put("testTag", "testThing")
-        .put("host", "thing")
+        .put("host.hostname", "thing")
       val expectedBatch: MetricBatch = new MetricBatch(Seq(count1, count2, gauge, histogramGauge, histogramSummary).asJava, expectedCommonAttributes)
 
       val tagDetails = ConfigValueFactory.fromMap(Map("testTag" -> "testThing").asJava)

--- a/src/test/scala/kamon/newrelic/spans/NewRelicSpanReporterSpec.scala
+++ b/src/test/scala/kamon/newrelic/spans/NewRelicSpanReporterSpec.scala
@@ -77,7 +77,7 @@ class NewRelicSpanReporterSpec extends WordSpec with Matchers {
     val commonAttributes = new Attributes()
       .put("instrumentation.provider", "kamon-agent")
       .put("service.name", serviceName)
-      .put("host", hostName)
+      .put("host.hostname", hostName)
       .put("testTag", tagValue)
     val expectedSpans = List(expectedSpan).asJava
     new SpanBatch(expectedSpans, commonAttributes)


### PR DESCRIPTION
Also, a couple of tweaks to the reporting:
use host.hostname to report the host
include the secondary user-agent for metrics.
resolves #18